### PR TITLE
enable unused variable

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,6 @@ disable=bad-continuation,         ######## Disabled because of conflicts with bl
         consider-using-enumerate, ######## Temporary disabled ########
         import-error,
         too-many-statements,
-        unused-variable,
 
 [DESIGN]
 max-args=7

--- a/continuous-integration/lint.sh
+++ b/continuous-integration/lint.sh
@@ -15,7 +15,14 @@ flake8 --config="$ROOT_DIR/.flake8" $pythonFiles || exit $?
 
 echo Running pylint on:
 echo "$pythonFiles"
-pylint -j 0 --rcfile "$ROOT_DIR/.pylintrc" --extension-pkg-whitelist=netCDF4 $pythonFiles || exit $?
+
+pylint \
+    -j 0 \
+    --rcfile "$ROOT_DIR/.pylintrc" \
+    --dummy-variables-rgx="((^|, )(app|rgb|xyz|contrast))+$" \
+    --extension-pkg-whitelist=netCDF4 \
+    $pythonFiles \
+    || exit $?
 
 echo Running darglint on:
 echo "$pythonFiles"


### PR DESCRIPTION
This is one of the main unused variables and I am not sure how to deal with it.

app = zivid.Application()

Also, in read_zdf.py, I want to show how to extract xyz, rgb, and contrast from the point_cloud. It is not used but the point is to show how one can get access to.

Any ideas?
