### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Note: The version tested with Zivid cameras is 1.4.0.
 
 2. [**Install Zivid Python**](https://github.com/zivid/zivid-python).
 
-3. Launch your Python IDE. Read our instructions on [**setting up Python**](https://zivid.atlassian.net/wiki/spaces/ZividKB/pages/427556/Setting+up+Python).
+3. [Optional] Launch the Python IDE of your choice. Read our instructions on [**setting up Python**](https://zivid.atlassian.net/wiki/spaces/ZividKB/pages/427556/Setting+up+Python).
 
 4. Install the runtime requirements using IDE or command line:
 


### PR DESCRIPTION
Use of an IDE is optional. Choice of IDE is free. I will also emphasize this in the instructions we link to.

Should we also update the instructions to state version 1.5.0. Or, maybe remove this altogether? We're not limited to either 1.4.0 OR 1.5.0, right?