### PR TITLE
Raise section in docstring

### DIFF
--- a/downsample.py
+++ b/downsample.py
@@ -59,6 +59,9 @@ def _downsample(xyz, rgb, contrast, downsampling_factor):
             size of the downsampled point cloud relative to the original point
             cloud, e.g. 2 - one-half, 3 - one-third, 4 one-quarter, etc.
 
+    Raises:
+        ValueError: If downsampling factor is not correct.
+
     Returns:
         Tuple of downsampled point cloud and color image.
     """


### PR DESCRIPTION
flake8 began raising this error:
/host/downsample.py:52:1: DAR401 Missing exception(s) in Raises section: -r ValueError

Adding a raise section should fix this error