### PR TITLE
Change variable name

### DIFF
--- a/source/camera/basic/capture_assistant.py
+++ b/source/camera/basic/capture_assistant.py
@@ -13,11 +13,11 @@ def _main():
         ambient_light_frequency=AmbientLightFrequency.hz50,
     )
 
-    suggested_settings = zivid.capture_assistant.suggest_settings(
+    settings_list = zivid.capture_assistant.suggest_settings(
         camera, suggest_settings_parameters
     )
 
-    with zivid.hdr.capture(camera, suggested_settings) as hdr_frame:
+    with zivid.hdr.capture(camera, settings_list) as hdr_frame:
         hdr_frame.save("result.zdf")
 
 

--- a/source/camera/basic/capture_hdr.py
+++ b/source/camera/basic/capture_hdr.py
@@ -6,12 +6,12 @@ def _main():
     app = zivid.Application()
     camera = app.connect_camera()
 
-    settings_collection = [camera.settings for _ in range(3)]
-    settings_collection[0].iris = 14
-    settings_collection[1].iris = 21
-    settings_collection[2].iris = 35
+    settings_list = [camera.settings for _ in range(3)]
+    settings_list[0].iris = 14
+    settings_list[1].iris = 21
+    settings_list[2].iris = 35
 
-    with camera.capture(settings_collection) as hdr_frame:
+    with camera.capture(settings_list) as hdr_frame:
         hdr_frame.save("result.zdf")
 
 


### PR DESCRIPTION
Make variable names consistent across python samples.
This helps to simplify tutorials as they link to code snippets of different samples.