### PR TITLE
Samples: Fix quaternion unit label and axis-angle unit-vector check

### DIFF
--- a/modules/zividsamples/gui/widgets/pose_widget.py
+++ b/modules/zividsamples/gui/widgets/pose_widget.py
@@ -180,15 +180,14 @@ class BasePoseWidget(QWidget):
         return zivid.Matrix4x4(self.transformation_matrix.as_matrix())
 
     def _rotation_label_text(self) -> str:
-        degrees = (
-            " (°)"
-            if self.rotation_information.use_degrees
-            and self.rotation_information.rotation_format not in ["Quaternion", "Rotation Matrix"]
-            else (
-                " (rad)" if self.rotation_information.rotation_format not in ["Quaternion", "Rotation Matrix"] else ""
-            )
-        )
-        return f"Rotation as {self.rotation_information.rotation_format.name}{degrees}"
+        rotation_format = self.rotation_information.rotation_format
+        if rotation_format in [RotationFormats.quaternion, RotationFormats.rotation_matrix]:
+            degrees = ""
+        elif self.rotation_information.use_degrees:
+            degrees = " (°)"
+        else:
+            degrees = " (rad)"
+        return f"Rotation as {rotation_format.name}{degrees}"
 
     def _rotation_column_label_texts(self) -> List[str]:
         fmt = self.rotation_information.rotation_format

--- a/source/applications/advanced/hand_eye_calibration/pose_conversions.py
+++ b/source/applications/advanced/hand_eye_calibration/pose_conversions.py
@@ -59,7 +59,7 @@ class AxisAngle:
         if angle is None:
             self.angle = np.linalg.norm(axis)
             self.axis = axis / self.angle
-        elif np.linalg.norm(axis) != 0:
+        elif not np.isclose(np.linalg.norm(axis), 1.0):
             raise ValueError("Angle provided, but vector is not unit vector")
         else:
             self.angle: np.floating = np.floating(angle)


### PR DESCRIPTION
## Summary
- `AxisAngle.__init__` (pose_conversions.py) validated the axis by checking `norm(axis) != 0` instead of `!= 1`, so passing an explicit `angle` with a valid unit axis always raised `ValueError`. Currently dead code in this sample (never hit by `_main()`), but breaks the documented axis+angle constructor usage for any new caller.
- `BasePoseWidget._rotation_label_text` (pose_widget.py) compared the `RotationFormat` dataclass instance against plain strings (`"Quaternion"`, `"Rotation Matrix"`), which is never `True` since dataclass equality only matches same-type instances. This caused the `(deg)`/`(rad)` unit suffix to always be appended to the rotation label, even for unitless formats like Quaternion.

## Test plan
- [ ] Verify `pose_conversion_gui.py` no longer shows `(deg)`/`(rad)` next to the Quaternion/Rotation Matrix rotation label
- [ ] Verify `AxisAngle(unit_axis, angle)` no longer raises `ValueError` for a valid unit axis
